### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Add publishing methods for channel resources ([#28](https://github.com/googleapis/python-eventarc-publishing/issues/28)) ([87d1e7b](https://github.com/googleapis/python-eventarc-publishing/commit/87d1e7bf20407dce888778454893b74640addf80))
 
-### [0.1.1](https://github.com/googleapis/python-eventarc-publishing/compare/v0.1.0...v0.1.1) (2022-03-05)
+## [0.1.1](https://github.com/googleapis/python-eventarc-publishing/compare/v0.1.0...v0.1.1) (2022-03-05)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.